### PR TITLE
Force regeneration

### DIFF
--- a/lib/jekyll/compass.rb
+++ b/lib/jekyll/compass.rb
@@ -34,6 +34,7 @@ module Jekyll
           :line_comments => false,
           :environment => :production,
           :output_style => :compact,
+          :force => true,
           #:quiet => true,
           :sass_options => {
               :unix_newlines => true,


### PR DESCRIPTION
So, hi...

I was passing through some problems when I am using the jekyll-compass plugins.

I was using it in [my blog](https://github.com/kelvinst/kelvinst.github.io), to use the compass sprites feature to make my blog rocks (it's in the start, but if you have some doubt from the rightness of the code, see my actual code at [here](https://github.com/kelvinst/kelvinst.github.io/tree/sprites)).

So, I'm almost sure that I make it all right (since it's very easy). Created the `_sass_` folder, and moved the .sass files to it. But, here comes the problem: each time that I `jekyll serve` my blog, **it toggles the css creation**. Once time creating the resulting css, and the other time removing it from the generated site.

Then, debuging and studying a little, I perceived that this is a jekyll's generators behavior. If I have something that was generated before, and is not generated now, then, this thing must be removed.

The compass command used, only generates the resulting css if the file changes ([here](https://github.com/chriseppstein/compass/blob/9ee6b422262668e8a7e154d2ac34f350ee331dc0/lib/compass/sass_extensions/sprites/sprite_methods.rb#L79) is the code that makes it). So, as you can see in the code, it was a `:force` option that you can pass to always regenerate.

It's what I've done!

Thanks...
