### PR TITLE
Sprite error

### DIFF
--- a/lib/jekyll/compass.rb
+++ b/lib/jekyll/compass.rb
@@ -53,7 +53,7 @@ module Jekyll
       ::Compass.configuration.on_sprite_removed do |filename|
         site.static_files = site.static_files.select do |p|
           if p.path == filename
-            sprite_output p.destination(site.config['destination'])
+            sprite_output = p.destination(site.config['destination'])
             File.delete sprite_output if File.exist? sprite_output
             false
           else


### PR DESCRIPTION
Now, when using sprites, I've got this error:

``` shel
λ jekyll build --trace
Configuration file: C:/wrks/git/kelvinst.github.io/_config.yml
            Source: C:/wrks/git/kelvinst.github.io
       Destination: C:/wrks/git/kelvinst.github.io/_site
      Generating...
   create images/icons-sbcaf79b2e7.png
   remove images/icons-sbcaf79b2e7.png
C:/RailsInstaller/Ruby1.9.3/lib/ruby/gems/1.9.1/gems/jekyll-compass-0.1.0/lib/jekyll/compass.rb:57:in `block (2 levels) in generate': undefined method `sprite_output' for #<Jekyll::Compass:0x4acdcd8> (NoMethodError)
        from C:/RailsInstaller/Ruby1.9.3/lib/ruby/gems/1.9.1/gems/jekyll-compass-0.1.0/lib/jekyll/compass.rb:55:in `select'
        from C:/RailsInstaller/Ruby1.9.3/lib/ruby/gems/1.9.1/gems/jekyll-compass-0.1.0/lib/jekyll/compass.rb:55:in `block in generate'
        from C:/RailsInstaller/Ruby1.9.3/lib/ruby/gems/1.9.1/gems/sass-3.2.12/lib/sass/callbacks.rb:60:in `[]'
        from C:/RailsInstaller/Ruby1.9.3/lib/ruby/gems/1.9.1/gems/sass-3.2.12/lib/sass/callbacks.rb:60:in `block in run_sprite_removed'
        ...
```

So, I fixed it...
